### PR TITLE
Fix DRC error in METAL4 for sky130_vsc.

### DIFF
--- a/benchs/8080/sky130_vsc/doDesign.py
+++ b/benchs/8080/sky130_vsc/doDesign.py
@@ -44,7 +44,7 @@ def scriptMain ( **kw ):
         conf.cfg.katana.hTracksReservedMin   = 5
         conf.cfg.katana.vTracksReservedMin   = 4
         conf.cfg.katana.hTracksReservedLocal = 9
-        conf.cfg.katana.vTracksReservedLocal = 9 
+        conf.cfg.katana.vTracksReservedLocal = 9
         conf.cfg.katana.termSatReservedLocal = 6 
         conf.cfg.katana.termSatThreshold     = 9 
         conf.cfg.katana.trackFill            = 0
@@ -53,7 +53,7 @@ def scriptMain ( **kw ):
         conf.useSpares = True
         conf.useHFNS   = False
         conf.useHTree( 'm_clock', Spares.HEAVY_LEAF_LOAD )
-        conf.coreSize  = ( l( 4200.0), l( 4200.0) )
+        conf.coreSize  = ( l( 4400.0), l( 4400.0) )
         conf.editor    = editor
         blockBuilder   = Block( conf )
         cell.setTerminalNetlist( False )

--- a/dks/sky130_vsc/libs.tech/coriolis/sky130_vsc/techno_symb.py
+++ b/dks/sky130_vsc/libs.tech/coriolis/sky130_vsc/techno_symb.py
@@ -180,7 +180,7 @@ def setup ():
     METAL3 .setMinimalSize   (           l(1.0) )
     METAL3 .setExtentionCap  ( metal3  , l(1.0) )
     METAL4 .setMinimalSize   (           l(1.0) )
-    METAL4 .setExtentionCap  ( metal4  , l(1.0) )
+    METAL4 .setExtentionCap  ( metal4  , l(2.0) )
     METAL4 .setMinimalSpacing(           l(3.0) )
     METAL5 .setMinimalSize   (           l(2.0) )
     METAL5 .setExtentionCap  ( metal5  , l(1.0) )


### PR DESCRIPTION
* Coriolis detailed router (Katana) deduce the minimum spacing between two segments in a track, starting for the start/end VIA center point, by adding the wire extension or the half of the VIA side (whichever is greater). In this case, the METAL4 extension of 1L was not enough, increased to 2L.